### PR TITLE
added option to fix the map on a specific coordinate

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ property and optionally `url` and `config` properties. If no `url` is supplied
 `name` is assumed to name a
 [Leaflet-provider](http://leaflet-extras.github.io/leaflet-providers/preview/).
 
+## fixedCenter (array, optional)
+
+This option allows to fix the map at one specific coordinate depending on following case-sensitive parameters:
+
+- `lat` latitude of the center point
+- `lng` longitude of the center point
+- `radius` visible radius around the center in km
+
+Examples for `fixedCenter`:
+
+    "fixedCenter": {
+      "lat": 50.80,
+      "lng": 12.07,
+      "radius": 30
+    }
+
 ## nodeInfos (array, optional)
 
 This option allows to show node statistics depending on following case-sensitive parameters:

--- a/lib/map.js
+++ b/lib/map.js
@@ -447,7 +447,10 @@ define(["map/clientlayer", "map/labelslayer",
         var lines = addLinksToMap(linkDict, linkScale, data.graph.links, router)
         groupLines = L.featureGroup(lines).addTo(map)
 
-        barycenter = calcBarycenter(data.nodes.all.filter(has_location))
+        if (typeof config.fixedCenter === "undefined")
+          barycenter = calcBarycenter(data.nodes.all.filter(has_location))
+        else
+          barycenter = L.circle(L.latLng(new L.LatLng(config.fixedCenter.lat, config.fixedCenter.lng)), config.fixedCenter.radius * 1000)
 
         var nodesOnline = subtract(data.nodes.all.filter(online), data.nodes.new)
         var nodesOffline = subtract(data.nodes.all.filter(offline), data.nodes.lost)


### PR DESCRIPTION
Zusätzliche Option um die Karte beim Laden auf einem Punkt zu fixieren, um z.B. die ganze Community drauf zu haben.

Im Speziellen haben wir das Phänomen, dass wir durch unsere 841v10 Firmware (welche bei uns funktioniert, aber noch nicht in allen anderen Communitys verfügbar ist) immer mehr Router in Berlin bekommen. Dadurch rutscht unser Kartenausschnitt immer mehr nach Norden, wodurch unsere eigenen südlichen Router nicht mehr zu sehen sind.