### PR TITLE
Added support for iframes in config

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -73,6 +73,13 @@ function localStorageTest() {
   }
 }
 
+function listReplace(s, subst) {
+  for (key in subst) {
+    s = s.replace(key, subst[key])
+  }
+  return s
+}
+
 /* Helpers working with nodes */
 
 function offline(d) {
@@ -138,3 +145,77 @@ function attributeEntry(el, label, value) {
 
   return td
 }
+
+function createIframe(opt, width, height) {
+  el = document.createElement("iframe")
+  width = typeof width !== 'undefined' ? width : '525px';
+  height = typeof height !== 'undefined' ? width : '350px';
+
+  if (opt.src)
+    el.src = opt.src
+  else
+    el.src = opt
+
+  if (opt.frameBorder)
+    el.frameBorder = opt.frameBorder
+  else
+    el.frameBorder = 1
+
+  if (opt.width)
+    el.width = opt.width
+  else
+    el.width = width
+
+  if (opt.height)
+    el.height = opt.height
+  else
+    el.height = height
+
+  el.scrolling = "no"
+  el.seamless = "seamless"
+
+  return el
+}
+
+function showStat(o, subst) {
+  var content, caption
+  subst = typeof subst !== 'undefined' ? subst : {};
+
+  if (o.thumbnail) {
+    content = document.createElement("img")
+    content.src = listReplace(o.thumbnail, subst)
+  }
+
+  if (o.caption) {
+    caption = listReplace(o.caption, subst)
+
+    if (!content)
+    content = document.createTextNode(caption)
+  }
+
+  if (o.iframe) {
+    content = createIframe(o.iframe)
+    if (o.iframe.src)
+    content.src = listReplace(o.iframe.src, subst)
+    else
+    content.src = listReplace(o.iframe, subst)
+  }
+
+  var p = document.createElement("p")
+
+  if (o.href) {
+    var link = document.createElement("a")
+    link.target = "_blank"
+    link.href = listReplace(o.href, subst)
+    link.appendChild(content)
+
+    if (caption && o.thumbnail)
+    link.title = caption
+
+    p.appendChild(link)
+  } else
+    p.appendChild(content)
+
+  return p
+}
+

--- a/lib/infobox/link.js
+++ b/lib/infobox/link.js
@@ -1,35 +1,9 @@
 define(function () {
   function showStatImg(o, source, target) {
-    var content, caption
-
-    if (o.thumbnail) {
-      content = document.createElement("img")
-      content.src = o.thumbnail.replace("{SOURCE}", source).replace("{TARGET}", target)
-    }
-
-    if (o.caption) {
-      caption = o.caption.replace("{SOURCE}", source).replace("{TARGET}", target)
-
-      if (!content)
-        content = document.createTextNode(caption)
-    }
-
-    var p = document.createElement("p")
-
-    if (o.href) {
-      var link = document.createElement("a")
-      link.target = "_blank"
-      link.href = o.href.replace("{SOURCE}", source).replace("{TARGET}", target)
-      link.appendChild(content)
-
-      if (caption && o.thumbnail)
-        link.title = caption
-
-      p.appendChild(link)
-    } else
-      p.appendChild(content)
-
-    return p
+    var subst = {}
+    subst["{SOURCE}"] = source
+    subst["{TARGET}"] = target
+    return showStat(o, subst)
   }
 
   return function (config, el, router, d) {

--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -220,36 +220,9 @@ define(["moment", "numeral", "tablesort", "tablesort.numeric"],
   }
 
   function showStatImg(o, nodeId) {
-    var content, caption
-
-    if (o.thumbnail) {
-      content = document.createElement("img")
-      content.src = o.thumbnail.replace("{NODE_ID}", nodeId)
-    }
-
-    if (o.caption) {
-      caption = o.caption.replace("{NODE_ID}", nodeId)
-
-      if (!content)
-        content = document.createTextNode(caption)
-    }
-
-    var p = document.createElement("p")
-
-    if (o.href) {
-      var link = document.createElement("a")
-      link.target = "_blank"
-      link.href = o.href.replace("{NODE_ID}", nodeId)
-      link.appendChild(content)
-
-      if (caption && o.thumbnail)
-        link.title = caption
-
-      p.appendChild(link)
-    } else
-      p.appendChild(content)
-
-    return p
+    var subst = {}
+    subst["{NODE_ID}"] = nodeId
+    return showStat(o, subst)
   }
 
   return function(config, el, router, d) {

--- a/lib/proportions.js
+++ b/lib/proportions.js
@@ -30,36 +30,7 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
     siteTable.classList.add("proportion")
 
     function showStatGlobal(o) {
-      var content, caption
-
-      if (o.thumbnail) {
-        content = document.createElement("img")
-        content.src = o.thumbnail
-      }
-
-      if (o.caption) {
-        caption = o.caption
-
-        if (!content)
-          content = document.createTextNode(caption)
-      }
-
-      var p = document.createElement("p")
-
-      if (o.href) {
-        var link = document.createElement("a")
-        link.target = "_blank"
-        link.href = o.href
-        link.appendChild(content)
-
-        if (caption && o.thumbnail)
-          link.title = caption
-
-        p.appendChild(link)
-      } else
-        p.appendChild(content)
-
-      return p
+      return showStat(o)
     }
 
     function count(nodes, key, f) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "node": true
     },
     "globals": {
+      "showStat": false,
       "attributeEntry": false,
       "dictGet": false,
       "getJSON": false,


### PR DESCRIPTION
Added support for iframes to be included through config.json in order to display live node-, link-, and global details plots.
The iframe config option takes precedence over the thumbnail option if both are present.
