### PR TITLE
Fixed client-dots and labels not showing on zoom levels >= 19

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -290,6 +290,12 @@ define(["map/clientlayer", "map/labelslayer",
         }
       })
 
+      var maxLayerZoom = Math.max.apply(Math, config.mapLayers.map(
+        function(d) {
+          return (typeof d.config !== "undefined" && typeof d.config.maxZoom !== "undefined") ? d.config.maxZoom : 18
+        }))
+
+
       layers[0].layer.addTo(map)
 
       layers.forEach( function (d) {
@@ -320,11 +326,11 @@ define(["map/clientlayer", "map/labelslayer",
           d.forEach(addLayer)
       }
 
-      var clientLayer = new ClientLayer({minZoom: 15})
+      var clientLayer = new ClientLayer({minZoom: 15, maxZoom: maxLayerZoom})
       clientLayer.addTo(map)
       clientLayer.setZIndex(5)
 
-      var labelsLayer = new LabelsLayer()
+      var labelsLayer = new LabelsLayer({maxZoom: maxLayerZoom})
       labelsLayer.addTo(map)
       labelsLayer.setZIndex(6)
 


### PR DESCRIPTION
This commits checks whether a maxZoom is set for a mapLayer in config.json and sets maxZoom on the client and label layers to the maximum value of these maxZoom values.

If no maxZoom was given, the leaflet default maxZoom of 18 is assumed.