### PR TITLE
stats: Fix inaccuracies if lat or long is missing

### DIFF
--- a/lib/proportions.js
+++ b/lib/proportions.js
@@ -159,7 +159,7 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
       var fwDict = count(nodes, ["nodeinfo", "software", "firmware", "release"])
       var hwDict = count(nodes, ["nodeinfo", "hardware", "model"])
       var geoDict = count(nodes, ["nodeinfo", "location"], function (d) {
-        return d ? "ja" : "nein"
+        return d && d.longitude && d.latitude ? "ja" : "nein"
       })
 
       var autoDict = count(nodes, ["nodeinfo", "software", "autoupdater"], function (d) {


### PR DESCRIPTION
We hit a bug where the counts on the statistics page were inaccurate.

For "Auf der Karte sichtbar", even nodes with latitude or longitude missing were counted, even though they are not actually visible on the map.

Please note that issue freifunk-gluon/gluon#703 exists, so this case might be pretty common in existing communites. In addition, if the user sets the coordinate via UCI and bypasses the LUCI validation, this may happen as well, so it is a good idea to make the frontend more resilient for missing data.