### PR TITLE
Save selected layer in local storage

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -172,7 +172,7 @@ define(["map/clientlayer", "map/labelslayer",
 
       var map, userLocation
       var layerControl
-      var customLayers = new Set()
+      var customLayers = {}
       var baseLayers = {}
 
       var locateUserButton = new LocateButton(function (d) {
@@ -259,16 +259,16 @@ define(["map/clientlayer", "map/labelslayer",
         if (layerName in baseLayers)
           return
 
-        if (customLayers.has(layerName))
+        if (layerName in customLayers)
           return
 
         try {
           var layer = L.tileLayer.provider(layerName)
           layerControl.addBaseLayer(layer, layerName)
-          customLayers.add(layerName)
+          customLayers[layerName] = layer
 
           if (localStorageTest())
-            localStorage.setItem("map/customLayers", JSON.stringify(Array.from(customLayers)))
+            localStorage.setItem("map/customLayers", JSON.stringify(Object.keys(customLayers)))
         } catch (e) {
           return
         }
@@ -324,7 +324,20 @@ define(["map/clientlayer", "map/labelslayer",
 
         if (d)
           d.forEach(addLayer)
+
+        d = JSON.parse(localStorage.getItem("map/selectedLayer"))
+        d = d && d.name in baseLayers ? baseLayers[d.name] : d && d.name in customLayers ? customLayers[d.name] : false
+
+        if (d) {
+          map.removeLayer(layers[0].layer)
+          map.addLayer(d)
+        }
       }
+
+      map.on("baselayerchange", function(e) {
+        if (localStorageTest())
+          localStorage.setItem("map/selectedLayer", JSON.stringify({name: e.name}))
+      })
 
       var clientLayer = new ClientLayer({minZoom: 15, maxZoom: maxLayerZoom})
       clientLayer.addTo(map)


### PR DESCRIPTION
People usually want their client to remember settings, in this case map layer selection. This will store the selected map layer in a local storage item ("map/selectedLayer"). customLayers is now a map storing a reference to the layer instance, so it is possible to show a custom layer without using the layerControl.