### PR TITLE
Replace MapQuest with OpenStreetMap.HOT in example config

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -5,14 +5,8 @@
   "showContact": true,
   "maxAge": 14,
   "mapLayers": [
-    { "name": "MapQuest",
-      "url": "https://otile{s}-s.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.jpg",
-      "config": {
-        "subdomains": "1234",
-        "type": "osm",
-        "attribution": "Tiles &copy; <a href=\"https://www.mapquest.com/\" target=\"_blank\">MapQuest</a>, Data CC-BY-SA OpenStreetMap",
-        "maxZoom": 18
-      }
+    {
+      "name": "OpenStreetMap.HOT"
     },
     {
       "name": "Stamen.TonerLite"


### PR DESCRIPTION
MapQuest Open Tiles service is announced to be discontinued and already started removing tiles at the highest zoom level. MapQuest provides a replacement service requiring custom javascript code to be injected, which I don't consider a good idea.
OpenStreetMap.HOT is a OpenStreetMap map style using pastel colours and thus is lot better than Mapnik for rendering stuff on it.