### PR TITLE
Dynamically select maxLayerZoom

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -290,12 +290,6 @@ define(["map/clientlayer", "map/labelslayer",
         }
       })
 
-      var maxLayerZoom = Math.max.apply(Math, config.mapLayers.map(
-        function(d) {
-          return (typeof d.config !== "undefined" && typeof d.config.maxZoom !== "undefined") ? d.config.maxZoom : 18
-        }))
-
-
       layers[0].layer.addTo(map)
 
       layers.forEach( function (d) {
@@ -334,18 +328,22 @@ define(["map/clientlayer", "map/labelslayer",
         }
       }
 
-      map.on("baselayerchange", function(e) {
-        if (localStorageTest())
-          localStorage.setItem("map/selectedLayer", JSON.stringify({name: e.name}))
-      })
-
-      var clientLayer = new ClientLayer({minZoom: 15, maxZoom: maxLayerZoom})
+      var clientLayer = new ClientLayer({minZoom: 15})
       clientLayer.addTo(map)
       clientLayer.setZIndex(5)
 
-      var labelsLayer = new LabelsLayer({maxZoom: maxLayerZoom})
+      var labelsLayer = new LabelsLayer({})
       labelsLayer.addTo(map)
       labelsLayer.setZIndex(6)
+
+      map.on("baselayerchange", function(e) {
+        map.options.maxZoom = e.layer.options.maxZoom
+        clientLayer.options.maxZoom = map.options.maxZoom
+        labelsLayer.options.maxZoom = map.options.maxZoom
+        if (map.getZoom() > map.options.maxZoom) map.setZoom(map.options.maxZoom)
+        if (localStorageTest())
+          localStorage.setItem("map/selectedLayer", JSON.stringify({name: e.name}))
+      })
 
       var nodeDict = {}
       var linkDict = {}


### PR DESCRIPTION
Fixes clients/names being hidden accidentally (in certain conditions). Also added auto-zoom-out to ensure zoom is in bounds