### PR TITLE
show amount of offline nodes to avoid confusion

### DIFF
--- a/lib/meshstats.js
+++ b/lib/meshstats.js
@@ -6,6 +6,7 @@ define(function () {
     self.setData = function (d) {
       var totalNodes = sum(d.nodes.all.map(one))
       var totalOnlineNodes = sum(d.nodes.all.filter(online).map(one))
+      var totalOfflineNodes = sum(d.nodes.all.filter(function (node) {return !node.flags.online}).map(one))
       var totalNewNodes = sum(d.nodes.new.map(one))
       var totalLostNodes = sum(d.nodes.lost.map(one))
       var totalClients = sum(d.nodes.all.filter(online).map( function (d) {
@@ -16,6 +17,7 @@ define(function () {
       }).map(one))
 
       var nodetext = [{ count: totalOnlineNodes, label: "online" },
+                      { count: totalOfflineNodes, label: "offline" },
                       { count: totalNewNodes, label: "neu" },
                       { count: totalLostNodes, label: "verschwunden" }
                      ].filter( function (d) { return d.count > 0 } )


### PR DESCRIPTION
I and a few others got confused by the fact that the amount of 'online' nodes and 'lost' nodes often don't sum up to the count of all nodes. I think displaying the amount of offline nodes would make clear that 'lost' nodes and 'offline' nodes are not the same.