### PR TITLE
Shorten device name in sidebar stats

### DIFF
--- a/lib/proportions.js
+++ b/lib/proportions.js
@@ -128,7 +128,13 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
         return d ? "online" : "offline"
       })
       var fwDict = count(nodes, ["nodeinfo", "software", "firmware", "release"])
-      var hwDict = count(nodes, ["nodeinfo", "hardware", "model"])
+      var hwDict = count(nodes, ["nodeinfo", "hardware", "model"], function (d) {
+        if (d) {
+          d = d.replace(/\(r\)|\(tm\)/gi, "").replace(/AMD |Intel |TP-Link | CPU| Processor/g, "")
+          if (d.indexOf("@") > 0) d = d.substring(0, d.indexOf("@"))
+        }
+        return d
+      })
       var geoDict = count(nodes, ["nodeinfo", "location"], function (d) {
         return d && d.longitude && d.latitude ? "ja" : "nein"
       })


### PR DESCRIPTION
This way, version codes on TP-Link devices and processor names are visible