### PR TITLE
Properly handle link types

### DIFF
--- a/lib/forcegraph.js
+++ b/lib/forcegraph.js
@@ -214,7 +214,7 @@ define(["d3"], function (d3) {
 
     function drawLabel(d) {
       var neighbours = d.neighbours.filter(function (d) {
-        return d.link.o.isDirect
+        return !d.link.o.isVPN
       })
 
       var sum = neighbours.reduce(function (a, b) {
@@ -332,8 +332,8 @@ define(["d3"], function (d3) {
         ctx.moveTo(d.source.x + dx * nodeRadius, d.source.y + dy * nodeRadius)
         ctx.lineTo(d.target.x - dx * nodeRadius, d.target.y - dy * nodeRadius)
         ctx.strokeStyle = d.o.type === "Kabel" ? cableColor : d.color
-        ctx.globalAlpha = !d.o.isDirect ? 0.1 : 0.8
-        ctx.lineWidth = !d.o.isDirect ? 1.5 : 2.5
+        ctx.globalAlpha = d.o.isVPN ? 0.1 : 0.8
+        ctx.lineWidth = d.o.isVPN ? 1.5 : 2.5
         ctx.stroke()
       })
 
@@ -523,7 +523,7 @@ define(["d3"], function (d3) {
       }
 
       var links = intLinks.filter(function (d) {
-        return d.o.isDirect
+        return !d.o.isVPN
       }).filter(function (d) {
         return distanceLink(e, d.source, d.target) < LINE_RADIUS
       })
@@ -584,13 +584,13 @@ define(["d3"], function (d3) {
               .charge(-250)
               .gravity(0.1)
               .linkDistance(function (d) {
-                if (!d.o.isDirect)
+                if (d.o.isVPN)
                   return 0
                 else
                   return LINK_DISTANCE
               })
               .linkStrength(function (d) {
-                if (!d.o.isDirect)
+                if (d.o.isVPN)
                   return 0
                 else
                   return Math.max(0.5, 1 / d.o.tq)
@@ -644,7 +644,7 @@ define(["d3"], function (d3) {
         e.source = newNodesDict[d.source.id]
         e.target = newNodesDict[d.target.id]
 
-        if (!d.isDirect)
+        if (d.isVPN)
           e.color = "rgba(255, 255, 255, " + (0.6 / d.tq) + ")"
         else
           e.color = linkScale(d.tq).hex()

--- a/lib/forcegraph.js
+++ b/lib/forcegraph.js
@@ -214,7 +214,7 @@ define(["d3"], function (d3) {
 
     function drawLabel(d) {
       var neighbours = d.neighbours.filter(function (d) {
-        return d.link.o.type !== "fastd" && d.link.o.type !== "L2TP"
+        return d.link.o.isDirect
       })
 
       var sum = neighbours.reduce(function (a, b) {
@@ -332,8 +332,8 @@ define(["d3"], function (d3) {
         ctx.moveTo(d.source.x + dx * nodeRadius, d.source.y + dy * nodeRadius)
         ctx.lineTo(d.target.x - dx * nodeRadius, d.target.y - dy * nodeRadius)
         ctx.strokeStyle = d.o.type === "Kabel" ? cableColor : d.color
-        ctx.globalAlpha = d.o.type === "fastd" || d.o.type === "L2TP" ? 0.1 : 0.8
-        ctx.lineWidth = d.o.type === "fastd" || d.o.type === "L2TP" ? 1.5 : 2.5
+        ctx.globalAlpha = !d.o.isDirect ? 0.1 : 0.8
+        ctx.lineWidth = !d.o.isDirect ? 1.5 : 2.5
         ctx.stroke()
       })
 
@@ -523,7 +523,7 @@ define(["d3"], function (d3) {
       }
 
       var links = intLinks.filter(function (d) {
-        return d.o.type !== "fastd" && d.o.type !== "L2TP"
+        return d.o.isDirect
       }).filter(function (d) {
         return distanceLink(e, d.source, d.target) < LINE_RADIUS
       })
@@ -584,13 +584,13 @@ define(["d3"], function (d3) {
               .charge(-250)
               .gravity(0.1)
               .linkDistance(function (d) {
-                if (d.o.type === "fastd" || d.o.type === "L2TP")
+                if (!d.o.isDirect)
                   return 0
                 else
                   return LINK_DISTANCE
               })
               .linkStrength(function (d) {
-                if (d.o.type === "fastd" || d.o.type === "L2TP")
+                if (!d.o.isDirect)
                   return 0
                 else
                   return Math.max(0.5, 1 / d.o.tq)
@@ -644,7 +644,7 @@ define(["d3"], function (d3) {
         e.source = newNodesDict[d.source.id]
         e.target = newNodesDict[d.target.id]
 
-        if (d.type === "fastd" || d.type === "L2TP")
+        if (!d.isDirect)
           e.color = "rgba(255, 255, 255, " + (0.6 / d.tq) + ")"
         else
           e.color = linkScale(d.tq).hex()

--- a/lib/main.js
+++ b/lib/main.js
@@ -128,25 +128,25 @@ function (moment, Router, L, GUI, numeral) {
       links.forEach( function (d) {
         if (d.type === "tunnel") {
           d.type = "VPN"
-          d.isDirect = false
+          d.isVPN = true
         } else if (d.type === "fastd") {
           d.type = "fastd"
-          d.isDirect = false
+          d.isVPN = true
         } else if (d.type === "l2tp") {
           d.type = "L2TP"
-          d.isDirect = false
+          d.isVPN = true
         } else if (d.type === "gre") {
           d.type = "GRE"
-          d.isDirect = false
+          d.isVPN = true
         } else if (d.type === "wireless") {
           d.type = "Wifi"
-          d.isDirect = true
+          d.isVPN = false
         } else if (d.type === "other") {
           d.type = "Kabel"
-          d.isDirect = true
+          d.isVPN = false
         } else {
           d.type = "N/A"
-          d.isDirect = false
+          d.isVPN = false
         }
         var unknown = (d.source.node === undefined)
         if (unknown) {
@@ -155,7 +155,7 @@ function (moment, Router, L, GUI, numeral) {
         }
         d.source.node.neighbours.push({ node: d.target.node, link: d, incoming: false })
         d.target.node.neighbours.push({ node: d.source.node, link: d, incoming: true })
-        if (d.isDirect)
+        if (!d.isVPN)
           d.source.node.meshlinks = d.source.node.meshlinks ? d.source.node.meshlinks + 1 : 1
       })
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -126,17 +126,28 @@ function (moment, Router, L, GUI, numeral) {
       })
 
       links.forEach( function (d) {
-        if (d.type === "tunnel" || d.type === "fastd")
+        if (d.type === "tunnel") {
+          d.type = "VPN"
+          d.isDirect = false
+        } else if (d.type === "fastd") {
           d.type = "fastd"
-        else if (d.type === "l2tp") {
+          d.isDirect = false
+        } else if (d.type === "l2tp") {
           d.type = "L2TP"
-          d.target.node.flags.uplink = true
-        } else if (d.type === "wireless")
+          d.isDirect = false
+        } else if (d.type === "gre") {
+          d.type = "GRE"
+          d.isDirect = false
+        } else if (d.type === "wireless") {
           d.type = "Wifi"
-        else if (d.type === "other")
+          d.isDirect = true
+        } else if (d.type === "other") {
           d.type = "Kabel"
-        else
+          d.isDirect = true
+        } else {
           d.type = "N/A"
+          d.isDirect = false
+        }
         var unknown = (d.source.node === undefined)
         if (unknown) {
           d.target.node.neighbours.push({ id: d.source.id, link: d, incoming: true })
@@ -144,7 +155,7 @@ function (moment, Router, L, GUI, numeral) {
         }
         d.source.node.neighbours.push({ node: d.target.node, link: d, incoming: false })
         d.target.node.neighbours.push({ node: d.source.node, link: d, incoming: true })
-        if (d.type !== "fastd" && d.type !== "L2TP")
+        if (d.isDirect)
           d.source.node.meshlinks = d.source.node.meshlinks ? d.source.node.meshlinks + 1 : 1
       })
 


### PR DESCRIPTION
1. This will add a key isDirect to each link, so you don't have to query for `== l2tp || == fastd` everywhere
2. It will create back the tunnel = "VPN" value and add an additional value "GRE"

Having tunnel not named "fastd" is the only right thing. "tunnel" devices are recognized by gluon/respondd based on the fact that it is a tun device, but this is not only the case for fastd, but other VPNs as well. hopglass-server should decide if it is a fastd connection or not (see my other pull request)