### PR TITLE
Make sure hopglass does not break when server reports nodes without hostname

### DIFF
--- a/lib/nodelist.js
+++ b/lib/nodelist.js
@@ -21,7 +21,11 @@ define(["sorttable", "virtual-dom", "numeral"], function (SortTable, V, numeral)
 
   var headings = [{ name: "Knoten",
                     sort: function (a, b) {
-                      return a.nodeinfo.hostname.localeCompare(b.nodeinfo.hostname)
+                      var aname = typeof a.nodeinfo.hostname === "string" ? a.nodeinfo.hostname : a.nodeinfo.node_id
+                      var bname = typeof b.nodeinfo.hostname === "string" ? b.nodeinfo.hostname : b.nodeinfo.node_id
+                      if (typeof aname === "string" && typeof bname === "string")
+                        return aname.localeCompare(bname)
+                      return typeof aname === "string" ? 1 : typeof bname === "string" ? -1 : 0
                     },
                     reverse: false
                   },


### PR DESCRIPTION
Currently it can happen that you see some error about missing "localeCompare" function if hostname is not a string.Use node_id as alternative to hostname for sorting.