### PR TITLE
Use resolved data if gateway was already resolved

### DIFF
--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -317,6 +317,9 @@ define(["moment", "numeral", "tablesort", "tablesort.numeric"],
     if (!d)
       return null
 
+    if (d.node || d.id)
+      return d
+
     var node = nodeDict[d.substr(0, 8)]
     if (!node)
       return d

--- a/lib/proportions.js
+++ b/lib/proportions.js
@@ -155,6 +155,12 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
         if (d === null)
           return null
 
+        if (d.node)
+          return d.node.nodeinfo.hostname
+
+        if (d.id)
+          return d.id
+
         var n = nodeDict[d.substr(0, 8)]
         if (!n)
           return d
@@ -168,6 +174,12 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
       var gwClientsDict = countClients(onlineNodes, ["statistics", "gateway"], function (d) {
         if (d === null)
           return null
+
+        if (d.node)
+          return d.node.nodeinfo.hostname
+
+        if (d.id)
+          return d.id
 
         var n = nodeDict[d.substr(0, 8)]
         if (!n)


### PR DESCRIPTION
This is now very dirty, I think the old approach was better (although it requires a server side change).

The reason the old approach did not work for eulenfunk is that it requires the flag gateway to be present which is not the case for your aliases.

Maybe the better solution is to lift [the gateway flag restriction from the hopglass-server](https://github.com/hopglass/hopglass-server/blob/master/modules/provider/hopglass.js#L40) and revert the new resolve code from hopglass.

The new code also has a small bug not present in the old version (verified on map.eulenfunk.de): when filtering nodes by selecting info from statistics, the gateway node might no longer be present in the active nodeset and is then no longer resolved. (this problem is not present when the old approach is used with this patch, because the resolving is done in advance)