### PR TITLE
Add loading animation and change order of displayed offline nodes

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -14,5 +14,15 @@
     </script>
   </head>
   <body>
+  <div class="loader">
+  <p>
+    Lade<br />
+    <span class="spinner"></span><br />
+    Karte &amp; Knoten...
+  </p>
+  <noscript>
+      <strong>JavaScript required</strong>
+  </noscript>
+  </div>
   </body>
 </html>

--- a/lib/gui.js
+++ b/lib/gui.js
@@ -47,6 +47,9 @@ function (chroma, Map, Sidebar, Tabs, Container, Meshstats, Legend, Linklist,
         addContent(K)
       }
     }
+    
+    var loader = document.getElementsByClassName("loader")[0]
+    loader.classList.add("hide")
 
     contentDiv = document.createElement("div")
     contentDiv.classList.add("content")

--- a/lib/gui.js
+++ b/lib/gui.js
@@ -50,7 +50,7 @@ function (chroma, Map, Sidebar, Tabs, Container, Meshstats, Legend, Linklist,
     
     var loader = document.getElementsByClassName("loader")[0]
     loader.classList.add("hide")
-
+    
     contentDiv = document.createElement("div")
     contentDiv.classList.add("content")
     document.body.appendChild(contentDiv)

--- a/lib/gui.js
+++ b/lib/gui.js
@@ -47,10 +47,10 @@ function (chroma, Map, Sidebar, Tabs, Container, Meshstats, Legend, Linklist,
         addContent(K)
       }
     }
-    
+
     var loader = document.getElementsByClassName("loader")[0]
     loader.classList.add("hide")
-    
+
     contentDiv = document.createElement("div")
     contentDiv.classList.add("content")
     document.body.appendChild(contentDiv)

--- a/lib/map.js
+++ b/lib/map.js
@@ -490,8 +490,8 @@ define(["map/clientlayer", "map/labelslayer",
           }, router))
 
         groupOffline = L.featureGroup(markersOffline).addTo(map)
-        groupOnline = L.featureGroup(markersOnline).addTo(map)
         groupLost = L.featureGroup(markersLost).addTo(map)
+        groupOnline = L.featureGroup(markersOnline).addTo(map)
         groupNew = L.featureGroup(markersNew).addTo(map)
 
         var rtreeOnlineAll = rbush(9)
@@ -499,10 +499,10 @@ define(["map/clientlayer", "map/labelslayer",
         rtreeOnlineAll.load(data.nodes.all.filter(online).filter(has_location).map(mapRTree))
 
         clientLayer.setData(rtreeOnlineAll)
-        labelsLayer.setData({online: nodesOnline.filter(has_location),
-                             offline: nodesOffline.filter(has_location),
-                             new: data.nodes.new.filter(has_location),
-                             lost: data.nodes.lost.filter(has_location)
+        labelsLayer.setData({offline: nodesOffline.filter(has_location),
+                             lost: data.nodes.lost.filter(has_location),
+                             online: nodesOnline.filter(has_location),
+                             new: data.nodes.new.filter(has_location)
                             })
 
         updateView(true)

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -28,3 +28,7 @@ h5 {
 h6 {
   font-size: 0.67em;
 }
+
+.hide {
+  display: none;
+}

--- a/scss/_loader.scss
+++ b/scss/_loader.scss
@@ -1,0 +1,23 @@
+.loader {
+  color: #000000;
+  font-size: 1.8em;
+  line-height: 2;
+  margin: 30vh auto;
+  text-align: center;
+}
+
+.spinner {
+  animation: .6s spinner ease-in-out infinite alternate;
+  border-bottom: 2px solid #000000;
+  border-radius: 50%;
+  display: inline-block;
+  height: 64px;
+  margin-top: 10px;
+  width: 64px;
+}
+
+@keyframes spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -4,6 +4,7 @@
 @import '_leaflet';
 @import '_leaflet.label';
 @import '_filters';
+@import '_loader';
 
 $minscreenwidth: 630pt;
 $sidebarwidth: 420pt;


### PR DESCRIPTION
This adds a simple loading animation, taken from the Freifunk Regensburg repository. It is especially useful for communities with a high number of nodes and clients because of the higher loading time.

The changes in the map.js change the order of the displayed offline nodes so that they are put behind the online nodes.