### PR TITLE
Updated DOP-NRW WMS URL

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -17,12 +17,12 @@
     },
     {
       "name": "Luftbilder NRW",
-      "url": "https://www.wms.nrw.de/geobasis/wms_nw_dop20?",
+      "url": "https://www.wms.nrw.de/geobasis/wms_nw_dop?",
       "config": {
         "maxZoom": 20,
         "attribution": "<a href=\"http://www.bezreg-koeln.nrw.de/brk_internet/geobasis/luftbilderzeugnisse/digitale_orthophotos/index.html\">DOP20</a>, Land NRW (2017), Datenlizenz Deutschland - Namensnennung - Version 2.0 (<a href=\"https://www.govdata.de/dl-de/by-2-0\">www.govdata.de/dl-de/by-2-0</a>)",
         "format": "image/jpeg",
-        "layers": "nw_dop20"
+        "layers": "nw_dop_rgb"
       }
     }
   ],


### PR DESCRIPTION
Der alte WMS Dienst für Luftbilder des Landes wird in Kürze abgeschaltet, dies ist der Neue.